### PR TITLE
remove unnecessary "from lib" statments

### DIFF
--- a/optimized_metrics/python/lib/auditory.py
+++ b/optimized_metrics/python/lib/auditory.py
@@ -6,8 +6,8 @@ All rights reserved
 import numpy as np
 import math
 from scipy import signal
-from lib import utils
-from lib import features  #import spectrum2scaletime, scaletime2scalerate, scalerate2cortical, waveform2auditoryspectrogram
+import utils
+import features  #import spectrum2scaletime, scaletime2scalerate, scalerate2cortical, waveform2auditoryspectrogram
 import matplotlib.pylab as plt
 
 


### PR DESCRIPTION
I was trying to use auditory.py in isolation. This is what I had to do (on colab) to make this work otherwise:

<code>
import sys
sys.path.append('/content/musical_timbre_studies/optimized_metrics/python')
</code>

Cheers!
-Max